### PR TITLE
This works even if `stowsh` not in PATH.

### DIFF
--- a/stowsh
+++ b/stowsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 _runcommands() {
     local prefix=''
@@ -121,8 +121,7 @@ stowsh_help() {
     echo "Usage: $0 [-D] [-n] [-s] [-v] PACKAGE [TARGET]"
 }
 
-
-if [[ $_ == "$0" ]]; then
+if [ "$0" = "$BASH_SOURCE" ]; then
     UNINSTALL=0
     DRYRUN=0
     SKIP=0


### PR DESCRIPTION
I run into problems while calling `stowsh` as a script from the command line.
I found the problem well described in the following:
http://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced/23009039#23009039

So now I can:
``` shell
./stowsh/stowsh PKG DIR
```
if `stowsh` is in a submodule.