### PR TITLE
Increased available verbosity (resolves #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ directory, creating subdirectories as necessary.
 
 ```bash
 $ stowsh -h
-Usage: stowsh [-D] [-n] [-s] [-v] PACKAGE [TARGET]
+Usage: stowsh [-D] [-n] [-s] [-v[v]] PACKAGE [TARGET]
 ```
 
 `TARGET` is the destination directory (current directory by default).
 
  - `-D` uninstall a package
  - `-n` dry-run (print what would happen, but don't do anything)
- - `-v` verbose
+ - `-v` verbose (`-vv` is even more verbose)
  - `-s` skip (skip errors rather than abort)
 
 When installing a package `stowsh` will never overwrite existing files. When

--- a/stowsh
+++ b/stowsh
@@ -172,10 +172,10 @@ if [ "$0" = "$BASH_SOURCE" ]; then
     for i in ${!PACKAGES[*]}; do
         pkg=${PACKAGES[$i]}
         if [[ $UNINSTALL -eq 1 ]]; then
-            if [[ $VERBOSE -eq 1 ]] ; then echoerr "uninstalling $pkg from $TARGET" ; fi
+            if [[ $VERBOSE -gt 0 ]] ; then echoerr "uninstalling $pkg from $TARGET" ; fi
             stowsh_uninstall "$pkg" "$TARGET"
         else
-            if [[ $VERBOSE -eq 1 ]] ; then echoerr "installing $pkg to $TARGET" ; fi
+            if [[ $VERBOSE -gt 0 ]] ; then echoerr "installing $pkg to $TARGET" ; fi
             stowsh_install "$pkg" "$TARGET"
         fi
     done

--- a/stowsh
+++ b/stowsh
@@ -2,10 +2,12 @@
 
 _runcommands() {
     local prefix=''
-    if [[ $DRYRUN == 1 ]]; then
-        prefix='echo'
+    if [[ $DRYRUN == 1 ]] || [[ $VERBOSE -gt 1 ]]; then
+        echo "$@"
     fi
-    eval $prefix "$@"
+    if [[ $DRYRUN != 1 ]]; then
+        eval "$@"
+    fi
 }
 
 echoerr() {
@@ -118,13 +120,14 @@ stowsh_uninstall() {
 }
 
 stowsh_help() {
-    echo "Usage: $0 [-D] [-n] [-s] [-v] PACKAGE [TARGET]"
+    echo "Usage: $0 [-D] [-n] [-s] [-v[v]] PACKAGE [TARGET]"
 }
 
 if [ "$0" = "$BASH_SOURCE" ]; then
     UNINSTALL=0
     DRYRUN=0
     SKIP=0
+    VERBOSE=0
     OPTIND=1 
     while getopts "vhDsn" opt; do
         case "$opt" in
@@ -138,7 +141,7 @@ if [ "$0" = "$BASH_SOURCE" ]; then
             ;;
         s)  SKIP=1
             ;;
-        v)  VERBOSE=1
+        v)  VERBOSE=$((VERBOSE + 1))
             ;;
         esac
     done
@@ -153,10 +156,10 @@ if [ "$0" = "$BASH_SOURCE" ]; then
     target=${2-$PWD}
     
     if [[ $UNINSTALL -eq 1 ]]; then
-        if [[ $VERBOSE -eq 1 ]] ; then echoerr "uninstalling $1 from $target" ; fi
+        if [[ $VERBOSE -gt 0 ]] ; then echoerr "uninstalling $1 from $target" ; fi
         stowsh_uninstall "$pkg" "$target"
     else
-        if [[ $VERBOSE -eq 1 ]] ; then echoerr "installing $1 to $target" ; fi
+        if [[ $VERBOSE -gt 0 ]] ; then echoerr "installing $1 to $target" ; fi
         stowsh_install "$pkg" "$target"
     fi
 fi


### PR DESCRIPTION
Specifying `-vv` increases verbosity to show every command executed (as it is being run, as opposed to `-n` which only prints the commands). `-v` works exactly as before.

---

Was this what was intended by #3, or were you wanting it to print a line for every individual file and directory change?