### PR TITLE
Multiple packages (resolves #9, resolves #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ directory, creating subdirectories as necessary.
 
 ```bash
 $ stowsh -h
-Usage: stowsh [-D] [-n] [-s] [-v] PACKAGE [TARGET]
+Usage: stowsh [-D] [-n] [-s] [-v] [-t TARGET] PACKAGES...
 ```
 
 `TARGET` is the destination directory (current directory by default).
@@ -114,8 +114,7 @@ $ tree -a
     └── pkg2
         └── bin
             └── script2
-$ stowsh .dotfiles/pkg1
-$ stowsh .dotfiles/pkg2
+$ stowsh .dotfiles/pkg1 .dotfiles/pkg2
 $ tree -a -I '.dotfiles'  # exclude ./.dotfiles from tree listing
 .
 ├── .conf
@@ -140,8 +139,7 @@ When uninstalling a package, subdirectories will only be deleted if they are
 empty. So:
 
 ```bash
-$ stowsh -D .dotfiles/pkg1
-$ stowsh -D .dotfiles/pkg2
+$ stowsh -D .dotfiles/pkg1 .dotfiles/pkg2
 $ tree -a -I '.dotfiles'
 .
 └── .conf

--- a/stowsh
+++ b/stowsh
@@ -50,6 +50,7 @@ stowsh_install() {
     target=$( "$rpcmd" "${2-$PWD}" )
     local commands=()
 
+    (
     cd "$pkg" || return 1
     dirs="$($findcmd . -mindepth 1 -type d | sed "s|./||")"
     for d in $dirs ; do
@@ -77,6 +78,7 @@ stowsh_install() {
     for cmd in "${commands[@]}"; do
         _runcommands "$cmd"
     done;
+    )
 }
 
 stowsh_uninstall() {
@@ -86,6 +88,7 @@ stowsh_uninstall() {
     target=$( "$rpcmd" "${2-$PWD}" )
     local commands=()
 
+    (
     cd "$pkg" || return 1
     local files
     files="$($findcmd . -type f -or -type l | sed "s|./||")"
@@ -115,21 +118,23 @@ stowsh_uninstall() {
     for cmd in "${commands[@]}"; do
         _runcommands "$cmd"
     done;
+    )
 }
 
 stowsh_help() {
-    echo "Usage: $0 [-D] [-n] [-s] [-v] PACKAGE [TARGET]"
+    echo "Usage: $0 [-D] [-n] [-s] [-v] [-t TARGET] PACKAGES..."
 }
 
 if [ "$0" = "$BASH_SOURCE" ]; then
     UNINSTALL=0
     DRYRUN=0
     SKIP=0
+    TARGET="$PWD"
     PACKAGES=()
     while [[ "$@" ]]; do
         if [[ $1 =~ ^- ]]; then
             OPTIND=1
-            while getopts ":vhDsn" opt; do
+            while getopts ":vhDsnt:" opt; do
                 case $opt in
                     h)
                         stowsh_help
@@ -143,6 +148,8 @@ if [ "$0" = "$BASH_SOURCE" ]; then
                         ;;
                     v)  VERBOSE=1
                         ;;
+                    t)  TARGET="$OPTARG"
+                        ;;
                     *)  echo "'$OPTARG' is an invalid option/flag"
                         exit 1
                         ;;
@@ -155,19 +162,19 @@ if [ "$0" = "$BASH_SOURCE" ]; then
         fi
     done
 
-    if [[ -z "${PACKAGES[0]}" ]] ; then
+    if [[ ${#PACKAGES[@]} -eq 0 ]] ; then
         stowsh_help
         exit 1
     fi
 
-    pkg=${PACKAGES[0]}
-    target=${PACKAGES[1]-$PWD}
-    
-    if [[ $UNINSTALL -eq 1 ]]; then
-        if [[ $VERBOSE -eq 1 ]] ; then echoerr "uninstalling $pkg from $target" ; fi
-        stowsh_uninstall "$pkg" "$target"
-    else
-        if [[ $VERBOSE -eq 1 ]] ; then echoerr "installing $pkg to $target" ; fi
-        stowsh_install "$pkg" "$target"
-    fi
+    for i in ${!PACKAGES[*]}; do
+        pkg=${PACKAGES[$i]}
+        if [[ $UNINSTALL -eq 1 ]]; then
+            if [[ $VERBOSE -eq 1 ]] ; then echoerr "uninstalling $pkg from $TARGET" ; fi
+            stowsh_uninstall "$pkg" "$TARGET"
+        else
+            if [[ $VERBOSE -eq 1 ]] ; then echoerr "installing $pkg to $TARGET" ; fi
+            stowsh_install "$pkg" "$TARGET"
+        fi
+    done
 fi

--- a/stowsh
+++ b/stowsh
@@ -125,38 +125,49 @@ if [ "$0" = "$BASH_SOURCE" ]; then
     UNINSTALL=0
     DRYRUN=0
     SKIP=0
-    OPTIND=1 
-    while getopts "vhDsn" opt; do
-        case "$opt" in
-        h)
-            stowsh_help
-            exit 0
-            ;;
-        D)  UNINSTALL=1
-            ;;
-        n)  DRYRUN=1
-            ;;
-        s)  SKIP=1
-            ;;
-        v)  VERBOSE=1
-            ;;
-        esac
+    PACKAGES=()
+    while [[ "$@" ]]; do
+        if [[ $1 =~ ^- ]]; then
+            OPTIND=1
+            while getopts ":vhDsn" opt; do
+                case $opt in
+                    h)
+                        stowsh_help
+                        exit 0
+                        ;;
+                    D)  UNINSTALL=1
+                        ;;
+                    n)  DRYRUN=1
+                        ;;
+                    s)  SKIP=1
+                        ;;
+                    v)  VERBOSE=1
+                        ;;
+                    *)  echo "'$OPTARG' is an invalid option/flag"
+                        exit 1
+                        ;;
+                esac
+            done
+            shift $((OPTIND-1))
+        else
+            PACKAGES+=("$1")
+            shift
+        fi
     done
-    shift $((OPTIND-1))
-    
-    if [[ -z ${1} ]] ; then
+
+    if [[ -z "${PACKAGES[0]}" ]] ; then
         stowsh_help
         exit 1
     fi
 
-    pkg=${1}
-    target=${2-$PWD}
+    pkg=${PACKAGES[0]}
+    target=${PACKAGES[1]-$PWD}
     
     if [[ $UNINSTALL -eq 1 ]]; then
-        if [[ $VERBOSE -eq 1 ]] ; then echoerr "uninstalling $1 from $target" ; fi
+        if [[ $VERBOSE -eq 1 ]] ; then echoerr "uninstalling $pkg from $target" ; fi
         stowsh_uninstall "$pkg" "$target"
     else
-        if [[ $VERBOSE -eq 1 ]] ; then echoerr "installing $1 to $target" ; fi
+        if [[ $VERBOSE -eq 1 ]] ; then echoerr "installing $pkg to $target" ; fi
         stowsh_install "$pkg" "$target"
     fi
 fi


### PR DESCRIPTION
Allows stowsh to accept multiple packages on the command line. Required sticking main bodies of `stowsh_install` and `stowsh_uninstall` inside of subshells, though they could have been reworked to not require `cd`.

:warning: This introduces backwards-incompatible changes as the target is now specified through a flag instead of being the last argument. I couldn't figure out a robust, user-friendly way to automatically decide if the last argument was intended to be a target or a package. Fortunately, as arguments can now be specified in any order, fixing calls is as simple as adding `-t`, e.g. `stowsh -Dv pkg1 pkg2 -t target`.